### PR TITLE
🎨 Design: waiting room 공통 컴포넌트 구현 #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.8",
+    "vite-plugin-svgr": "^4.3.0",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/src/assets/images/crown.svg
+++ b/src/assets/images/crown.svg
@@ -8,7 +8,7 @@
 Created by potrace 1.10, written by Peter Selinger 2001-2011
 </metadata>
 <g transform="translate(0.000000,200.000000) scale(0.100000,-0.100000)"
-fill="#000000" stroke="none">
+fill="currentColor" stroke="none">
 <path d="M986 1894 c-20 -20 -20 -43 3 -127 32 -118 75 -138 135 -64 22 27 40
 64 48 97 l12 53 -32 28 c-28 25 -40 29 -91 29 -41 0 -65 -5 -75 -16z"/>
 <path d="M1658 1899 c-22 -12 -22 -32 -2 -95 20 -57 40 -84 65 -84 27 0 71 64

--- a/src/components/common/WaitingRoom.tsx
+++ b/src/components/common/WaitingRoom.tsx
@@ -1,7 +1,40 @@
-export default function WaitingRoom() {
+import kisu from '../../assets/images/kisu_.svg';
+import Crown from '../..//assets/images/crown.svg?react';
+
+type WaitingRoomProps = {
+  avatar?: string;
+  name: string;
+  isReady?: boolean;
+  isLeader: boolean;
+};
+
+export default function WaitingRoom({
+  avatar,
+  name,
+  isReady,
+  isLeader,
+}: WaitingRoomProps) {
   return (
     <>
-      <h1>WaitingRoom Component</h1>
+      <div className="w-[321px] h-[77px] px-7 bg-[var(--white)] flex justify-between items-center text-[16px] font-bold rounded-md border-2 border-[var(--black)]">
+        <div className="flex items-center gap-[7px]">
+          <img
+            src={avatar ? avatar : kisu}
+            alt="캐릭터"
+            className="w-[49px] h-[49px]"
+          />
+          <div className="flex items-center gap-[7px] w-[140px]">
+            <div className="truncate">{name}</div>
+            {isLeader && <Crown className="w-[18px] h-[15px] text-[#F4EC5A]" />}
+          </div>
+        </div>
+        {!isLeader &&
+          (isReady ? (
+            <div className="text-[var(--blue)] w-[50px]">Ready</div>
+          ) : (
+            <div className="text-[var(--red)] w-[60px]">Waiting</div>
+          ))}
+      </div>
     </>
   );
 }

--- a/src/components/common/WaitingRoom.tsx
+++ b/src/components/common/WaitingRoom.tsx
@@ -1,0 +1,7 @@
+export default function WaitingRoom() {
+  return (
+    <>
+      <h1>WaitingRoom Component</h1>
+    </>
+  );
+}

--- a/src/components/common/WaitingRoom.tsx
+++ b/src/components/common/WaitingRoom.tsx
@@ -30,9 +30,9 @@ export default function WaitingRoom({
         </div>
         {!isLeader &&
           (isReady ? (
-            <div className="text-[var(--blue)] w-[50px]">Ready</div>
+            <div className="text-[var(--blue)] w-[50px]">READY</div>
           ) : (
-            <div className="text-[var(--red)] w-[60px]">Waiting</div>
+            <div className="text-[var(--red)] w-[60px]">waiting</div>
           ))}
       </div>
     </>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />

--- a/svg.d.ts
+++ b/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: React.FC<React.SVGProps<SVGElement>>;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,9 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["vite-plugin-svgr/client"]
+  },
+  "include": ["svg.d.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import vitePluginSvgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), vitePluginSvgr()],
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#13 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

게임 대기방에 입장 시 보이는 사용자 컴포넌트를 만들었습니다.
방장은 이름 옆에 왕관 아이콘이 보이고, 다른 사용자들은 준비 상태 여부가 보입니다.
상의 후 글자 크기 18px에서 16px로 변경했습니다.

왕관에 색을 지정하기 위해 vite-plugin-svgr 패키지를 설치했습니다.

```
<WaitingRoom
  avatar={kisu} name="hellohello" isReady={true} isLeader={false} />
```

### 스크린샷 (선택)
<img width="164" alt="스크린샷 2025-06-09 10 41 34" src="https://github.com/user-attachments/assets/d377e8e7-ab1c-4364-a94c-12fa4395a9df" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
