### PR TITLE
🎨 Design: 공통 컴포넌트 Chat Message 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,7 @@
-import ChatMessage from "./components/common/ChatMessage";
-
 export default function App() {
   return (
     <>
       <h1>App Component</h1>
-      <div className="w-full justify-center items-center flex flex-col">
-        <ChatMessage />
-      </div>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
+import ChatMessage from "./components/common/ChatMessage";
+
 export default function App() {
   return (
     <>
       <h1>App Component</h1>
+      <div className="w-full justify-center items-center flex flex-col">
+        <ChatMessage />
+      </div>
     </>
   );
 }

--- a/src/components/common/ChatMessage.tsx
+++ b/src/components/common/ChatMessage.tsx
@@ -1,0 +1,7 @@
+export default function ChatMessage () {
+  return (
+    <>
+      <h1>ChatMessage</h1>
+    </>
+  );
+}

--- a/src/components/common/ChatMessage.tsx
+++ b/src/components/common/ChatMessage.tsx
@@ -1,7 +1,48 @@
-export default function ChatMessage () {
+import type { HTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
+
+type ChatMessageProps = HTMLAttributes<HTMLDivElement> & {
+  userName: string;
+  message: string;
+  isMine: boolean;
+  size?: "small" | "large";
+};
+
+export default function ChatMessage({
+  userName,
+  message,
+  isMine,
+  size = "small",
+  className,
+  ...props
+}: ChatMessageProps) {
+  const containerClass = twMerge(
+    "flex w-full",
+    isMine ? "justify-end flex-row-reverse" : "justify-start",
+    className
+  );
+
+  const messageClass = twMerge(
+    "rounded-[6px] px-4 py-2 break-words text-[color:var(--white)]",
+    size === "small" ? "text-sm max-w-[180px]" : "text-base max-w-[320px]",
+    isMine ? "bg-[color:var(--blue)]" : "bg-[color:var(--grey-200-40)]"
+  );
+
+  const userNameClass = twMerge(
+    "font-bold text-[color:var(--black)] text-base"
+  );
+
   return (
-    <>
-      <h1>ChatMessage</h1>
-    </>
+    <div className={containerClass} {...props}>
+      <div
+        className={twMerge(
+          "flex flex-col w-full gap-2",
+          isMine ? "items-end" : "items-start"
+        )}
+      >
+        <span className={userNameClass}>{userName}</span>
+        <div className={messageClass}>{message}</div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#20 
## 📝작업 내용

> 채팅 메시지를 표시하는 재사용 가능한 ChatMessage 컴포넌트를 구현했습니다.

방향 설정: isMine prop에 따라 내 메시지는 오른쪽, 상대방 메시지는 왼쪽 정렬
크기 옵션: small(최대 180px), large(최대 320px) 두 가지 크기 지원
텍스트 줄바꿈: 긴 텍스트가 말풍선을 벗어나지 않도록 적용 (break-words)

## ⚒️사용방법
```ts
<div className="w-full justify-center items-center flex flex-col gap-30 mt-30">
        <div className="w-[584px]">
          <ChatMessage
            userName="수코딩"
            message="안녕하세요 저는 수코딩입니다. 저는 very Handsome합니다. 동의하십니까?"
            isMine={false}
            size="large"
          />
          <ChatMessage
            userName="준규"
            message="비동의."
            isMine={true}
            size="large"
          />
        </div>
        <div className="w-[287px]">
          <ChatMessage
            userName="수코딩"
            message="저는 Handsome합니다. 동의하십니까?"
            isMine={false}
            size="small"
          />
          <ChatMessage
            userName="준규"
            message="?"
            isMine={true}
            size="small"
          />
        </div>
      </div>
```

### 스크린샷 (선택)
![Screenshot 2025-06-09 at 10 50 50 AM](https://github.com/user-attachments/assets/094f5a36-d6fd-47a1-86e9-afd38538df1e)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
