### PR TITLE
✨ Feature: (싱글모드) 제시어 관리를 위한 전역 상태 관리 스토어를 구현

### DIFF
--- a/src/components/game/DrawingPropmt.tsx
+++ b/src/components/game/DrawingPropmt.tsx
@@ -1,0 +1,11 @@
+export default function DrawingPropmt({ topic }: { topic: string }) {
+  return (
+    <>
+      <div className="flex w-[597px] h-[62px] border-[2px] border-[color:var(--black)] rounded-[6px] text-center items-center justify-center">
+        <p className="font-semibold text-[18px] text-[color:var(--black)]">
+          {topic}
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/stores/drawingStore.ts
+++ b/src/stores/drawingStore.ts
@@ -1,0 +1,66 @@
+import { create } from "zustand";
+
+export const topicListData = [
+  "cat",
+  "dog",
+  "bird",
+  "fish",
+  "elephant",
+  "tiger",
+  "bear",
+  "cow",
+  "horse",
+  "sheep",
+  "car",
+  "house",
+  "tree",
+  "flower",
+  "sun",
+  "moon",
+  "star",
+  "apple",
+  "banana",
+  "umbrella",
+  "cup",
+  "scissors",
+  "guitar",
+  "piano",
+  "clock",
+  "book",
+  "chair",
+  "table",
+  "airplane",
+  "bicycle",
+];
+
+type DrawingState = {
+  topicList: string[];
+  currentTopic: string;
+  getRandomTopic: () => void;
+  resetTopicList: () => void;
+};
+
+export const useDrawingStore = create<DrawingState>((set, get) => ({
+  topicList: [...topicListData],
+  currentTopic: "",
+
+  getRandomTopic: () => {
+    const { topicList } = get();
+    if (topicList.length === 0) return;
+
+    const randomIndex = Math.floor(Math.random() * topicList.length);
+    const selectedTopic = topicList[randomIndex];
+
+    set((state) => ({
+      currentTopic: selectedTopic,
+      topicList: state.topicList.filter((topic) => topic !== selectedTopic),
+    }));
+  },
+
+  resetTopicList: () => {
+    set({
+      topicList: [...topicListData],
+      currentTopic: "",
+    });
+  },
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈
> #32 


## 📝작업 내용

> 그림 그리기 게임의 제시어 관리를 위한 전역 상태 관리 스토어를 구현

- 랜덤 제시어 선택: 중복 없이 랜덤하게 제시어 선택
- 사용된 제시어 제거: 선택된 제시어는 목록에서 자동 제거
- 제시어 목록 초기화: 모든 제시어를 다시 사용할 수 있도록 초기화
- DrawingPrompt 컴포넌트: 제시어 박스 구현

## ⚒️사용방법
```ts
 const { currentTopic, getRandomTopic } = useDrawingStore();

  useEffect(() => {
    getRandomTopic();
  }, []);

  return (
    <div>
      <DrawingPropmt topic={currentTopic}/>
    </div>
  );
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
